### PR TITLE
Improves search speed on stops

### DIFF
--- a/Carris Metropolitana/Services/CMAPI/CMAModels.swift
+++ b/Carris Metropolitana/Services/CMAPI/CMAModels.swift
@@ -91,6 +91,8 @@ struct Stop: Codable, Identifiable, Hashable {
     let lines: [String]?
     let routes: [String]?
     let patterns: [String]?
+    var nameNormalized: String?
+    var ttsNameNormalized: String?
     
 //    enum CodingKeys: String, CodingKey {
 //        case id, name, latitude, longitude, locality

--- a/Carris Metropolitana/Services/Persistent Data/StopsManager.swift
+++ b/Carris Metropolitana/Services/Persistent Data/StopsManager.swift
@@ -20,11 +20,19 @@ class StopsManager: ObservableObject {
 
     func fetchStops() {
         Task {
-            let newStops = await CMAPI.shared.getStops()
-            DispatchQueue.main.async {
-                self.stops = newStops
-                print("Got \(newStops.count) new stops!")
+            var newStops = await CMAPI.shared.getStops()
+            for i in newStops.indices {
+                newStops[i].nameNormalized = newStops[i].name.normalizedForSearch()
+                if let ttsName = newStops[i].ttsName {
+                    newStops[i].ttsNameNormalized = ttsName.normalizedForSearch()
+                }
             }
+            let modifiedStops = newStops
+            DispatchQueue.main.async {
+                self.stops = modifiedStops
+                print("Got \(modifiedStops.count) new stops!")
+            }
+            
         }
     }
 

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -225,8 +225,8 @@ struct StopsView: View {
                     }
                 }
 
-                // Execute the debounce work item after 250ms delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: debounceSearchItem!)
+                // Execute the debounce work item after 100ms delay
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: debounceSearchItem!)
             }
             
             


### PR DESCRIPTION
Two fixes are proposed

- Precomputation of normalized stop names. This should save 450 to 650ms per keystroke.
- Removal of location dependency on main view, and updating only on search open and on location change (with 1s debounce). This should save 150ms per keystroke.

Debounce on search was added, but this was sufficiently fast now (50ms) to do realtime, however, i propose not to do that. You can lower the debounce latency if necessary. 

Debounce on location change must not be removed as location can fluctuate too much.

Warnings:

- Users need to rebuild the stops database upon update. Suggested that there is a flow to do so in code.
- Cold start can increase once every stops update by 450-650ms for a one-time processing of stops (instead of per keystroke)