### PR TITLE
Improvements in clearing coordinate flights

### DIFF
--- a/Carris Metropolitana/Components/Maps/StopsMapView.swift
+++ b/Carris Metropolitana/Components/Maps/StopsMapView.swift
@@ -403,7 +403,7 @@ struct StopsMapView: UIViewRepresentable {
     func flyToCoordinate(on mapView: MLNMapView, to coordinate: CLLocationCoordinate2D) {
         let camera = MLNMapCamera(
             lookingAtCenter: coordinate,
-            altitude: 5500,
+            altitude: 1500,
             pitch: 0,
             heading: 0)
         

--- a/Carris Metropolitana/Components/Maps/StopsMapView.swift
+++ b/Carris Metropolitana/Components/Maps/StopsMapView.swift
@@ -417,7 +417,7 @@ struct StopsMapView: UIViewRepresentable {
         if let userLocation = mapView.userLocation {
             let camera = MLNMapCamera(
                 lookingAtCenter: userLocation.coordinate,
-                altitude: 5500,
+                altitude: 1500,
                 pitch: 0,
                 heading: 0)
             

--- a/Carris Metropolitana/Components/Maps/StopsMapView.swift
+++ b/Carris Metropolitana/Components/Maps/StopsMapView.swift
@@ -32,7 +32,7 @@ struct StopsMapView: UIViewRepresentable {
     
     let onStopSelect: (_ stopId: String) -> Void
     
-    var flyToCoords: CLLocationCoordinate2D?
+    @Binding var flyToCoords: CLLocationCoordinate2D?
     @Binding var shouldFlyToUserCoords: Bool
     
     var mapVisualStyle: MapVisualStyle = .standard
@@ -457,6 +457,7 @@ struct StopsMapView: UIViewRepresentable {
         if let flyToCoords = flyToCoords {
             flyToCoordinate(on: uiView, to: flyToCoords)
         }
+        flyToCoords = nil
         
         if shouldFlyToUserCoords {
             print("should fly to user coords is \(shouldFlyToUserCoords)")

--- a/Carris Metropolitana/Tab Views/Home/SelectFavoriteStopView.swift
+++ b/Carris Metropolitana/Tab Views/Home/SelectFavoriteStopView.swift
@@ -26,7 +26,7 @@ struct SelectFavoriteStopView: View {
             StopsMapView(stops: stopsManager.stops, onStopSelect: { stopId in
                 selectedStopId = stopId
                 presentationMode.wrappedValue.dismiss()
-            }, flyToCoords: nil, shouldFlyToUserCoords: .constant(false), showPopupOnStopSelect: true)
+            }, flyToCoords: .constant(nil), shouldFlyToUserCoords: .constant(false), showPopupOnStopSelect: true)
                 .frame(height: 300)
             
             List {

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -168,9 +168,6 @@ struct StopsView: View {
             }
             .onChange(of: mapFlyToUserCoords) {
                 print("map flying to user coords")
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    flyToCoords = nil
-                }
             }
             .onChange(of: stopsManager.stops) {
                 if stopsManager.stops.count > 0 {

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -101,7 +101,7 @@ struct StopsView: View {
                         isSheetPresented = true
                         print("Changed stopId to \(String(describing: selectedStopId))")
                     },
-                    flyToCoords: flyToCoords,
+                    flyToCoords: $flyToCoords,
                     shouldFlyToUserCoords: $mapFlyToUserCoords,
                     mapVisualStyle: mapVisualStyle
                 ).ignoresSafeArea().onDisappear {
@@ -313,11 +313,8 @@ struct StopsView: View {
                         isSheetPresented = true
                     }
                 }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: {
-                    flyToCoords = nil
-                    tabCoordinator.mapFlyToCoords = nil
-                    tabCoordinator.flownToStopId = nil
-                })
+                tabCoordinator.mapFlyToCoords = nil
+                tabCoordinator.flownToStopId = nil
             }
         }
     }
@@ -401,7 +398,6 @@ struct StopsView: View {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: {
                                 selectedStopId = stop.id
                                 isSheetPresented = true
-                                flyToCoords=nil
                             })
 
                         } label: {

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -311,9 +311,13 @@ struct StopsView: View {
                         flyToCoords = flyToCoordsFromExternalTab
                         selectedStopId = flownToStopIdFromExternalTab
                         isSheetPresented = true
-                        tabCoordinator.mapFlyToCoords = nil
                     }
                 }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: {
+                    flyToCoords = nil
+                    tabCoordinator.mapFlyToCoords = nil
+                    tabCoordinator.flownToStopId = nil
+                })
             }
         }
     }

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -168,6 +168,9 @@ struct StopsView: View {
             }
             .onChange(of: mapFlyToUserCoords) {
                 print("map flying to user coords")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    flyToCoords = nil
+                }
             }
             .onChange(of: stopsManager.stops) {
                 if stopsManager.stops.count > 0 {
@@ -311,6 +314,7 @@ struct StopsView: View {
                         flyToCoords = flyToCoordsFromExternalTab
                         selectedStopId = flownToStopIdFromExternalTab
                         isSheetPresented = true
+                        tabCoordinator.mapFlyToCoords = nil
                     }
                 }
             }
@@ -388,12 +392,17 @@ struct StopsView: View {
                 LazyVStack {
                     ForEach(searchFilteredStops) { stop in
                         Button {
-                            flyToCoords = CLLocationCoordinate2D(latitude: Double(stop.lat)!, longitude: Double(stop.lon)!)
-                            isSearching = false
-                            isSearchFieldFocused = false
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
-                                selectedStopId = stop.id
+                            DispatchQueue.main.async {
+                                isSearching = false
+                                isSearchFieldFocused = false
+                                flyToCoords = CLLocationCoordinate2D(latitude: Double(stop.lat)!, longitude: Double(stop.lon)!)
                             }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: {
+                                selectedStopId = stop.id
+                                isSheetPresented = true
+                                flyToCoords=nil
+                            })
+
                         } label: {
                             StopSearchResultEntry(stop: stop)
                                 .padding(.horizontal)


### PR DESCRIPTION
When flying to selected coordinates, it's good to ensure these are cleared as soon as the action is taken.
This is a very small fix that addresses this by setting the relevant vars to nil, and is not meant to replace your future work on the state management of the map.