### PR TITLE
Further stops fixes

### DIFF
--- a/Carris Metropolitana/Components/Maps/StopsMapView.swift
+++ b/Carris Metropolitana/Components/Maps/StopsMapView.swift
@@ -34,6 +34,7 @@ struct StopsMapView: UIViewRepresentable {
     
     var flyToCoords: CLLocationCoordinate2D?
     @Binding var shouldFlyToUserCoords: Bool
+    @Binding var mapVisible: Bool
     
     var mapVisualStyle: MapVisualStyle = .standard
     
@@ -182,11 +183,13 @@ struct StopsMapView: UIViewRepresentable {
         var control: StopsMapView
         var mapVisualStyle: MapVisualStyle // is this really how this is supposed to be done??
         var flyToCoords: CLLocationCoordinate2D?
+        var mapVisible: Bool = true
         
         init(_ control: StopsMapView) {
             self.control = control
             self.mapVisualStyle = control.mapVisualStyle
             self.flyToCoords = control.flyToCoords
+            self.mapVisible = control.mapVisible
         }
         
         @objc func handleTap(_ sender: UITapGestureRecognizer) {
@@ -261,6 +264,9 @@ struct StopsMapView: UIViewRepresentable {
         }
         
         func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
+            if (!mapVisible){
+                return
+            }
             print("MapView loaded Style -> \(mapVisualStyle)")
             if let image = UIImage(named: "CMMapSelectedStop") {
                 style.setImage(image, forName: "cm-map-selected-stop")
@@ -433,6 +439,9 @@ struct StopsMapView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: MLNMapView, context: Context) {
+        if (!mapVisible){
+            return
+        }
         print("StopsMapView updateUIView called")
         print("updateUIView called with \(stops.count) stops")
         

--- a/Carris Metropolitana/Tab Views/Home/SelectFavoriteStopView.swift
+++ b/Carris Metropolitana/Tab Views/Home/SelectFavoriteStopView.swift
@@ -26,7 +26,7 @@ struct SelectFavoriteStopView: View {
             StopsMapView(stops: stopsManager.stops, onStopSelect: { stopId in
                 selectedStopId = stopId
                 presentationMode.wrappedValue.dismiss()
-            }, flyToCoords: nil, shouldFlyToUserCoords: .constant(false), showPopupOnStopSelect: true)
+            }, flyToCoords: nil, shouldFlyToUserCoords: .constant(false), mapVisible: .constant(true), showPopupOnStopSelect: true)
                 .frame(height: 300)
             
             List {

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -186,14 +186,20 @@ struct StopsView: View {
             
             
             .onChange(of: isSearchFieldFocused) {
+                print("Search field focused, suggested stops count is \(suggestedStops.count)")
                 if(suggestedStops.count == 0){
+                // This should basically never run as
+                // - initial location is handled onAppear with async queued work and
+                // - location updates are handled by onChange of locationManager.location
                     if let location = locationManager.location {
+                        // This should basically never run as
+                        // - initial location is handled onAppear, and
+                        // - location updates are handled by onChange of locationManager.location
                         suggestedStops = closestStops(to: location.coordinate, stops: stopsManager.stops, maxResults: 10)
                     } else {
                         suggestedStops = Array(stopsManager.stops.prefix(10))
                     }
                 }
-                print("Search field focused, suggested stops count is \(suggestedStops.count)")
                 withAnimation(.smooth(duration: 0.2)) {
                     isSearching = isSearchFieldFocused
                 }
@@ -312,6 +318,16 @@ struct StopsView: View {
                         flyToCoords = flyToCoordsFromExternalTab
                         selectedStopId = flownToStopIdFromExternalTab
                         isSheetPresented = true
+                    }
+                }
+                // Initialize the suggested stops right at tab open - reduces delay in tapping search
+                DispatchQueue.main.async{
+                    if(suggestedStops.count == 0){
+                        if let location = locationManager.location {
+                            suggestedStops = closestStops(to: location.coordinate, stops: stopsManager.stops, maxResults: 10)
+                        } else {
+                            suggestedStops = Array(stopsManager.stops.prefix(10))
+                        }
                     }
                 }
             }

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -103,6 +103,7 @@ struct StopsView: View {
                     },
                     flyToCoords: flyToCoords,
                     shouldFlyToUserCoords: $mapFlyToUserCoords,
+                    mapVisible: $mapVisible,
                     mapVisualStyle: mapVisualStyle
                 ).ignoresSafeArea().onDisappear {
                     mapVisible = false
@@ -409,7 +410,13 @@ struct StopsView: View {
                 }
                 
             }
-            .contentMargins(.top, 70, for: .scrollContent)
+            .contentMargins(.top, 77, for: .scrollContent)
+        }
+        .onAppear(){
+            mapVisible = false
+        }
+        .onDisappear(){
+            mapVisible = true
         }
     }
     

--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -373,6 +373,9 @@ struct StopsView: View {
                 }
             }
         }
+        .onTapGesture {
+            isSearchFieldFocused = true
+        }
     }
     
     


### PR DESCRIPTION
- Early exiting of map redraws if map is not visible. 
- Entire search button is now fully tapable, leading to a more responsive experience.
- Populate suggestedStops before tapping search button
- A slight increase in spacing was done, this is mostly for the benefit of older smaller phones without significant impact to newer models.