### PR TITLE
Disable autocorrection as it's not ideal for typing stops and prevents a CoreGraphics API null

### DIFF
--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -349,7 +349,7 @@ struct StopsView: View {
                 }
                 TextField("", text: $searchTerm, prompt: Text("Nome ou número da paragem").foregroundColor(.gray).fontWeight(.semibold))
                     .padding(.leading, isSearching ? 18 : 0)
-                
+                    .autocorrectionDisabled()
                     .frame(height: 50)
                     .focused($isSearchFieldFocused)
                 //                            .background(.red)


### PR DESCRIPTION
Improves typing performance

Allows users to type the acronyms in stop names

Removes throwing error per-keystroke

`Error: this application, or a library it uses, has passed an invalid numeric value (NaN, or not-a-number) to CoreGraphics API and this value is being ignored. Please fix this problem.`