### PR TITLE
Fixes merge (both changes needed to be accepted)

### DIFF
--- a/Carris Metropolitana/Tab Views/Stops/StopsView.swift
+++ b/Carris Metropolitana/Tab Views/Stops/StopsView.swift
@@ -320,6 +320,8 @@ struct StopsView: View {
                         isSheetPresented = true
                     }
                 }
+                tabCoordinator.mapFlyToCoords = nil
+                tabCoordinator.flownToStopId = nil
                 // Initialize the suggested stops right at tab open - reduces delay in tapping search
                 DispatchQueue.main.async{
                     if(suggestedStops.count == 0){


### PR DESCRIPTION
In a prior pull request, there was a conflict on StopsView that to merge should have had accepted **both** changes, instead of the latter overwriting the previous.

This corrects the merger to add the missing lines, fixing the map still displaying the clicked stop when sent from another tab even after being displayed.